### PR TITLE
Fixing API build process

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,8 +18,10 @@ script:
   - yarn run lint
   - gulp models
   - cd ../backend
+  - yarn run ci:build
   - yarn run lint
   - yarn test
   - cd ../frontend
+  - yarn build
   - yarn run lint
   - yarn test

--- a/backend/package.json
+++ b/backend/package.json
@@ -5,6 +5,7 @@
   "main": "index.js",
   "scripts": {
     "build": "rm -rf dist && tsc -w",
+    "ci:build": "tsc --listFiles",
     "start": "npm run server",
     "server": "nodemon dist/server.js",
     "test": "ts-mocha src/**/*.spec.ts",

--- a/backend/src/core/services/Signup.ts
+++ b/backend/src/core/services/Signup.ts
@@ -1,4 +1,4 @@
-import { Signup as Presentation } from '../../../../models';
+import { Signup as Presentation } from '../../models-folder/presentations';
 import { Request } from 'express';
 import { User } from '../models/user';
 import IRepository from '../dal/IRepository';

--- a/backend/src/routes/controllers/user.ts
+++ b/backend/src/routes/controllers/user.ts
@@ -1,5 +1,3 @@
-// tslint:disable-next-line: no-implicit-dependencies
-import { Signup as Presentation } from '../../../../models';
 import { Signup as Service } from '../../core/services/Signup';
 import Repository from '../../core/dal/Repository';
 import { User as Model } from '../../core/models/user';

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -13,7 +13,7 @@
     "experimentalDecorators": true,
     "plugins": [{
       "name": "typescript-tslint-plugin"
-    }]
-  },
-  "include": ["src/**/*"]
+    }],
+    "types": ["mocha"],
+  }
 }

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -11,9 +11,11 @@
     "baseUrl": "./",
     "declaration": true,
     "experimentalDecorators": true,
-    "plugins": [{
-      "name": "typescript-tslint-plugin"
-    }],
-    "types": ["mocha"],
+    "plugins": [
+      {
+        "name": "typescript-tslint-plugin"
+      }
+    ],
+    "types": ["mocha"]
   }
 }

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -24,8 +24,5 @@
   },
   "include": [
     "src"
-  ],
-  "references": [{
-    "path": "../models"
-  }]
+  ]
 }

--- a/models/tsconfig.json
+++ b/models/tsconfig.json
@@ -14,7 +14,6 @@
     "plugins": [{
       "name": "typescript-tslint-plugin"
     }],
-    "composite": true,
   },
   "include": ["src/**/*"]
 }

--- a/tasks/gulpfile.js
+++ b/tasks/gulpfile.js
@@ -1,7 +1,4 @@
-const {
-  src,
-  dest
-} = require('gulp');
+const { src, dest } = require('gulp');
 const del = require('del');
 
 const modelsPath = '../models/lib';
@@ -10,14 +7,14 @@ const backendPath = '../backend/src/models-folder';
 
 const baseCopy = () => src(`${modelsPath}/**/*`);
 
-function models(cb) {
+async function models(cb) {
   console.log('deleting models in frontend folder');
-  del(`${frontendPath}/**`, {
+  await del(`${frontendPath}/**`, {
     force: true
   });
 
   console.log('deleting models in backend folder');
-  del(`${backendPath}/**`, {
+  await del(`${backendPath}/**`, {
     force: true
   });
 


### PR DESCRIPTION
The API wouldn't build because of Type ambiguity from Mocha and Jest.
Plus, nodemon wouldn't start because there was old references in the API making the compilation include de models folder.

Everything is fixed, plus a new security has been added to the CI pipeline